### PR TITLE
Add Google authentication for Firestore data

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', async function() {
+document.addEventListener('DOMContentLoaded', function() {
     // アプリケーションの状態
     const state = {
         currentPage: 'home',
@@ -7,56 +7,66 @@ document.addEventListener('DOMContentLoaded', async function() {
         dailyTasks: {},
         editMode: false,
         editingItem: null,
-        timeline: {} // 追加：タイムラインのデータ
+        timeline: {}, // 追加：タイムラインのデータ
+        userId: null
     };
 
-    // 初期データのロード（Firestoreから）
-    await loadDataFromFirestore();
-    // Firestore リアルタイム購読（他端末の変更を反映）
-    try {
-        if (typeof subscribeData === "function") {
-            // 端末識別ID（index側で発行）
-            const DEVICE_ID_KEY = "be-trillion-device-id";
-            const __deviceId = localStorage.getItem(DEVICE_ID_KEY) || "";
-            let __localMeta = null;
-            if (state && state._meta) __localMeta = state._meta;
+    function setupFirestoreSubscription() {
+        try {
+            if (typeof subscribeData === "function" && state.userId) {
+                const DEVICE_ID_KEY = "be-trillion-device-id";
+                const __deviceId = localStorage.getItem(DEVICE_ID_KEY) || "";
+                let __localMeta = state._meta || null;
 
-            window.__unsubscribeFirestore && window.__unsubscribeFirestore();
-            window.__unsubscribeFirestore = subscribeData("myUser", (data) => {
-                if (!data) return;
-                const remoteMeta = (data && data._meta) || null;
+                window.__unsubscribeFirestore && window.__unsubscribeFirestore();
+                window.__unsubscribeFirestore = subscribeData(state.userId, (data) => {
+                    if (!data) return;
+                    const remoteMeta = (data && data._meta) || null;
 
-                // 自分の直近保存は無視
-                if (remoteMeta && remoteMeta.deviceId && remoteMeta.deviceId === __deviceId) {
-                    state._meta = remoteMeta;
-                    return;
-                }
+                    if (remoteMeta && remoteMeta.deviceId && remoteMeta.deviceId === __deviceId) {
+                        state._meta = remoteMeta;
+                        return;
+                    }
 
-                const isNewer = !__localMeta || (remoteMeta && remoteMeta.updatedAt > __localMeta.updatedAt);
-                if (!isNewer) return;
+                    const isNewer = !__localMeta || (remoteMeta && remoteMeta.updatedAt > __localMeta.updatedAt);
+                    if (!isNewer) return;
 
-                state.activities = data.activities || [];
-                state.dailyTasks = data.dailyTasks || {};
-                state.timeline   = data.timeline   || {};
-                state._meta      = remoteMeta || null;
-                __localMeta      = state._meta;
+                    state.activities = data.activities || [];
+                    state.dailyTasks = data.dailyTasks || {};
+                    state.timeline   = data.timeline   || {};
+                    state._meta      = remoteMeta || null;
+                    __localMeta      = state._meta;
 
-                if (typeof renderHomePage === 'function') {
-                    // 既存の描画関数が多数あるはずなので、ホームに戻すか、現在ページを再描画
-                    renderHomePage();
-                } else if (typeof renderPage === "function") {
-                    renderPage(state.currentPage || "home");
-                }
-                if (typeof updateLastUpdated === "function") updateLastUpdated();
-            });
+                    if (typeof renderHomePage === 'function') {
+                        renderHomePage();
+                    } else if (typeof renderPage === "function") {
+                        renderPage(state.currentPage || "home");
+                    }
+                    if (typeof updateLastUpdated === "function") updateLastUpdated();
+                });
+            }
+        } catch (e) {
+            console.error("subscribeData error:", e);
         }
-    } catch (e) {
-        console.error("subscribeData error:", e);
     }
 
+    window.onUserLogin = async function(uid) {
+        state.userId = uid;
+        await loadDataFromFirestore();
+        setupFirestoreSubscription();
+        checkTimelineReset();
+        renderPage(state.currentPage);
+    };
 
-    // タイムラインのリセットをチェック
-    checkTimelineReset();
+    window.onUserLogout = function() {
+        state.userId = null;
+        window.__unsubscribeFirestore && window.__unsubscribeFirestore();
+        state.activities = [];
+        state.dailyTasks = {};
+        state.timeline = {};
+        state._meta = null;
+        renderPage('home');
+    };
 
     // アプリの初期化
     initApp();
@@ -64,14 +74,27 @@ document.addEventListener('DOMContentLoaded', async function() {
     // 現在の日付を設定
     updateCurrentDate();
 
+    if (window.__currentUser) {
+        window.onUserLogin(window.__currentUser.uid);
+    } else {
+        window.onUserLogout();
+    }
+
     // =====================
     // データ管理機能
     // =====================
 
     // Firestoreからデータをロード
     async function loadDataFromFirestore() {
+        if (!state.userId) {
+            const initialData = initializeData();
+            state.activities = initialData.activities;
+            state.dailyTasks = initialData.dailyTasks;
+            state.timeline   = {};
+            return;
+        }
         try {
-            const data = await loadData("myUser"); // ← index.htmlで定義済みの関数を呼ぶ
+            const data = await loadData(state.userId); // ← index.htmlで定義済みの関数を呼ぶ
             state.activities = data.activities || [];
             state.dailyTasks = data.dailyTasks || {};
             state.timeline   = data.timeline   || {};
@@ -95,9 +118,10 @@ document.addEventListener('DOMContentLoaded', async function() {
     }
 
     // Firestoreにデータを保存
- async function saveDataToFirestore() {
+    async function saveDataToFirestore() {
+        if (!state.userId) return;
         try {
-            const __meta = await saveData("myUser", { activities: state.activities, dailyTasks: state.dailyTasks, timeline: state.timeline });
+            const __meta = await saveData(state.userId, { activities: state.activities, dailyTasks: state.dailyTasks, timeline: state.timeline });
             state._meta = __meta || null;
             updateLastUpdated();
         } catch (error) {
@@ -351,7 +375,29 @@ document.addEventListener('DOMContentLoaded', async function() {
         } finally {
             // メインのナビゲーションにイベントリスナーを設定
             setupNavigationListeners();
+            setupAuthUI();
         }
+    }
+
+    function setupAuthUI() {
+        const accountBtn = document.getElementById('account-btn');
+        const dropdown = document.getElementById('account-dropdown');
+        const loginBtn = document.getElementById('login-btn');
+        const logoutBtn = document.getElementById('logout-btn');
+        if (!accountBtn || !dropdown) return;
+
+        accountBtn.onclick = () => {
+            dropdown.classList.toggle('open');
+        };
+
+        if (loginBtn) {
+            loginBtn.onclick = () => window.firebaseLogin && window.firebaseLogin();
+        }
+        if (logoutBtn) {
+            logoutBtn.onclick = () => window.firebaseLogout && window.firebaseLogout();
+        }
+
+        window.updateAuthUI && window.updateAuthUI(window.__currentUser);
     }
 
     // ホーム画面のデータをレンダリングする関数

--- a/index.html
+++ b/index.html
@@ -142,6 +142,14 @@
                 <h1 class="document-title">事業・活動進捗管理</h1>
                 <p class="document-subtitle">戦略的事業展開のためのマスタープラン</p>
                 <div class="document-date">最終更新: <span id="last-updated-date"></span></div>
+                <div class="account-menu">
+                    <button id="account-btn" class="account-icon"><i class="fas fa-user"></i></button>
+                    <div id="account-dropdown" class="account-dropdown">
+                        <div id="auth-status" class="account-status">ゲスト</div>
+                        <button id="login-btn">ログイン</button>
+                        <button id="logout-btn" style="display:none;">ログアウト</button>
+                    </div>
+                </div>
             </header>
             
             <nav class="document-nav">
@@ -781,10 +789,11 @@
         </div>
     </template>
 
-    <!-- Firebase 初期化と Firestore の設定 -->
+    <!-- Firebase 初期化と Firestore + Auth の設定 -->
     <script type="module">
       import { initializeApp } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js";
       import { getFirestore, doc, setDoc, getDoc, onSnapshot } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore.js";
+      import { getAuth, signInWithPopup, GoogleAuthProvider, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js";
 
       const firebaseConfig = {
         apiKey: "AIzaSyCCmNMhbz1G35de_AkkebVW53xAZc1kYwI",
@@ -798,6 +807,52 @@
 
       const app = initializeApp(firebaseConfig);
       const db = getFirestore(app);
+      const auth = getAuth(app);
+      const provider = new GoogleAuthProvider();
+
+      window.firebaseLogin = function() {
+        signInWithPopup(auth, provider).catch(err => console.error('login error:', err));
+      };
+
+      window.firebaseLogout = function() {
+        signOut(auth).catch(err => console.error('logout error:', err));
+      };
+
+      function getAuthElements() {
+        return {
+          loginBtn: document.getElementById('login-btn'),
+          logoutBtn: document.getElementById('logout-btn'),
+          authStatus: document.getElementById('auth-status')
+        };
+      }
+
+      window.updateAuthUI = function(user) {
+        const { loginBtn, logoutBtn, authStatus } = getAuthElements();
+        if (!authStatus) return;
+        if (user) {
+          authStatus.textContent = user.displayName || 'ユーザー';
+          if (loginBtn) loginBtn.style.display = 'none';
+          if (logoutBtn) logoutBtn.style.display = 'block';
+        } else {
+          authStatus.textContent = 'ゲスト';
+          if (loginBtn) loginBtn.style.display = 'block';
+          if (logoutBtn) logoutBtn.style.display = 'none';
+        }
+      };
+
+      onAuthStateChanged(auth, user => {
+        window.__currentUser = user;
+        window.updateAuthUI(user);
+        if (user) {
+          if (typeof window.onUserLogin === 'function') {
+            window.onUserLogin(user.uid);
+          }
+        } else {
+          if (typeof window.onUserLogout === 'function') {
+            window.onUserLogout();
+          }
+        }
+      });
 
       // 端末ID（自己エコーバック防止）
       const DEVICE_ID_KEY = "be-trillion-device-id";

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,59 @@ body {
     font-size: 14px;
 }
 
+
+.account-menu {
+    margin-top: 10px;
+    text-align: right;
+    position: relative;
+}
+
+.account-icon {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+.account-dropdown {
+    position: absolute;
+    right: 0;
+    top: 110%;
+    background: white;
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-shadow: var(--shadow);
+    display: none;
+    min-width: 120px;
+    z-index: 1000;
+}
+
+.account-dropdown.open {
+    display: block;
+}
+
+.account-status {
+    padding: 8px;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 0.9rem;
+}
+
+.account-dropdown button {
+    width: 100%;
+    padding: 8px;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.account-dropdown button:hover {
+    background-color: var(--accent-light);
+}
+
 .app-container {
     min-height: 100vh;
     display: flex;


### PR DESCRIPTION
## Summary
- integrate Firebase Auth with Google sign-in
- handle user-specific Firestore reads/writes
- add login/logout UI and styles
- replace top-right buttons with account icon dropdown below last updated

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd773892d0832ca1c8c8dc843c9dba