### PR TITLE
Remove home tab from KPI navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,7 +328,6 @@
             <nav class="document-nav">
                 <h2 class="nav-title">目次</h2>
                 <ul class="nav-links">
-                    <li><a href="#" data-page="home" class="nav-link">ホーム</a></li>
                     <li><a href="#" data-page="daily-tasks" class="nav-link">今日のタスク</a></li>
                     <li><a href="#" data-page="kpi-list" class="nav-link active">KPI一覧</a></li>
                 </ul>


### PR DESCRIPTION
## Summary
- KPI一覧テンプレート内のナビゲーションからホームタブを削除し、重複したリンクを解消

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbdc3b7eb4832cb21089417ee16d43