### PR TITLE
Remove medium-term planning section

### DIFF
--- a/app.js
+++ b/app.js
@@ -380,16 +380,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const completedActivities = state.activities.filter(a => a.progress >= 100 || a.completed);
         
         // 進行中と完了済みを除いたアクティビティ
-        const shortTermActivities = state.activities.filter(a => 
+        const shortTermActivities = state.activities.filter(a =>
             a.timeline === 'short-term' && a.progress < 20 && !a.completed);
-        const mediumTermActivities = state.activities.filter(a => 
-            a.timeline === 'medium-term' && a.progress < 20 && !a.completed);
-        const longTermActivities = state.activities.filter(a => 
-            a.timeline === 'long-term' && a.progress < 20 && !a.completed);
+        const longTermActivities = state.activities.filter(a =>
+            (a.timeline === 'long-term' || a.timeline === 'medium-term') && a.progress < 20 && !a.completed);
         
         // 事業数のカウントを更新
         document.getElementById('short-term-count').textContent = shortTermActivities.length;
-        document.getElementById('medium-term-count').textContent = mediumTermActivities.length;
         document.getElementById('long-term-count').textContent = longTermActivities.length;
         document.getElementById('in-progress-count').textContent = inProgressActivities.length;
         document.getElementById('completed-count').textContent = completedActivities.length;
@@ -397,7 +394,6 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // 各カテゴリごとに事業カードをレンダリング
         renderActivityCards('short-term-cards', shortTermActivities, 'short-term');
-        renderActivityCards('medium-term-cards', mediumTermActivities, 'medium-term');
         renderActivityCards('long-term-cards', longTermActivities, 'long-term');
         renderActivityCards('in-progress-cards', inProgressActivities, 'in-progress');
         renderActivityCards('completed-cards', completedActivities, 'completed');
@@ -506,13 +502,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 switch(zoneClass) {
                     case 'short-term':
                         activity.timeline = 'short-term';
-                        if (activity.completed) {
-                            activity.completed = false;
-                            needsUpdate = true;
-                        }
-                        break;
-                    case 'medium-term':
-                        activity.timeline = 'medium-term';
                         if (activity.completed) {
                             activity.completed = false;
                             needsUpdate = true;
@@ -1621,7 +1610,10 @@ document.addEventListener('DOMContentLoaded', function() {
         
         document.getElementById('activity-name').value = activity.name;
         document.getElementById('activity-purpose').value = activity.purpose;
-        document.getElementById('activity-timeline').value = activity.timeline;
+        const timelineField = document.getElementById('activity-timeline');
+        if (timelineField) {
+            timelineField.value = activity.timeline === 'short-term' ? 'short-term' : 'long-term';
+        }
         document.getElementById('activity-progress').value = activity.progress;
         
         // KPIの入力フィールドを作成
@@ -2019,7 +2011,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 this.classList.add('active');
 
                 // ホームページでのセクションジャンプ処理
-                if (state.currentPage === 'home' && ['short-term', 'medium-term', 'long-term', 'in-progress', 'completed'].includes(page)) {
+                if (state.currentPage === 'home' && ['short-term', 'long-term', 'in-progress', 'completed'].includes(page)) {
                     // ページ内のセクションにスクロール
                     const section = document.getElementById(page);
                     if (section) {

--- a/index.html
+++ b/index.html
@@ -53,10 +53,6 @@
                             <div class="stat-label">短期事業（3日以内）</div>
                         </div>
                         <div class="stat-item">
-                            <div class="stat-number" id="medium-term-count">4</div>
-                            <div class="stat-label">中期事業（1ヶ月以内）</div>
-                        </div>
-                        <div class="stat-item">
                             <div class="stat-number" id="long-term-count">5</div>
                             <div class="stat-label">長期事業（時期不明）</div>
                         </div>
@@ -103,23 +99,9 @@
                     </div>
                 </section>
                 
-                <section id="medium-term" class="document-section">
-                    <h2 class="section-title">中期計画（1ヶ月以内に開始）</h2>
-                    
-                    <div class="timeline-container">
-                        <div class="timeline-line"></div>
-                        <div class="timeline-group">
-                            <div class="timeline-marker medium-term"></div>
-                            <div class="timeline-cards" id="medium-term-cards">
-                                <!-- 中期的な事業カードがここに動的に挿入されます -->
-                            </div>
-                        </div>
-                    </div>
-                </section>
-                
                 <section id="long-term" class="document-section">
                     <h2 class="section-title">長期計画（時期不明）</h2>
-                    
+
                     <div class="timeline-container">
                         <div class="timeline-line"></div>
                         <div class="timeline-group">
@@ -149,10 +131,6 @@
                     <div class="legend-item">
                         <div class="legend-color short-term"></div>
                         <span class="legend-label">短期計画：3日以内に開始</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color medium-term"></div>
-                        <span class="legend-label">中期計画：1ヶ月以内に開始</span>
                     </div>
                     <div class="legend-item">
                         <div class="legend-color long-term"></div>
@@ -393,7 +371,6 @@
                         <label for="activity-timeline">期間</label>
                         <select id="activity-timeline" required>
                             <option value="short-term">短期（3日以内）</option>
-                            <option value="medium-term">中期（1ヶ月以内）</option>
                             <option value="long-term">長期（時期不明）</option>
                         </select>
                     </div>

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,6 @@
     --text-secondary: #5f6b7a;
     --bg-color: #f8f9fa;
     --short-term-color: #2980b9;
-    --medium-term-color: #27ae60;
     --long-term-color: #f39c12;
     --shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
     --card-radius: 6px;
@@ -337,10 +336,6 @@ body {
     background-color: var(--short-term-color);
 }
 
-.timeline-marker.medium-term {
-    background-color: var(--medium-term-color);
-}
-
 .timeline-marker.long-term {
     background-color: var(--long-term-color);
 }
@@ -419,10 +414,6 @@ body {
 
 .activity-card.short-term::before {
     background-color: var(--short-term-color);
-}
-
-.activity-card.medium-term::before {
-    background-color: var(--medium-term-color);
 }
 
 .activity-card.long-term::before {
@@ -513,10 +504,6 @@ body {
 
 .legend-color.short-term {
     background-color: var(--short-term-color);
-}
-
-.legend-color.medium-term {
-    background-color: var(--medium-term-color);
 }
 
 .legend-color.long-term {
@@ -1219,7 +1206,7 @@ body {
 }
 
 .edit-btn {
-    background-color: var(--medium-term-color);
+    background-color: #27ae60;
 }
 
 .edit-btn:hover {


### PR DESCRIPTION
## Summary
- remove the medium-term section, stats entry, legend item, and form option from the home and activity form templates
- update the dashboard logic to treat former medium-term activities as long-term, remove the unused drop zone, and adjust navigation behaviour
- clean up styling tied to the medium-term category while keeping the edit button colour consistent

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce5f8d6d70832cbace63c1ca3d105c