### PR TITLE
Remove activity purpose field

### DIFF
--- a/app.js
+++ b/app.js
@@ -423,7 +423,6 @@ document.addEventListener('DOMContentLoaded', function() {
             
             card.innerHTML = `
                 <h4 class="activity-name">${activity.name}</h4>
-                <p class="activity-purpose">${activity.purpose}</p>
                 <div class="activity-progress">
                     <div class="activity-progress-wrapper">
                         <div class="progress-bar-container">
@@ -605,7 +604,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!activity) return;
         
         document.getElementById('detail-activity-name').textContent = activity.name;
-        document.getElementById('detail-activity-purpose').textContent = activity.purpose;
         
         // 進捗バーを更新
         updateProgressDisplay(activity);
@@ -1609,7 +1607,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!activity) return;
         
         document.getElementById('activity-name').value = activity.name;
-        document.getElementById('activity-purpose').value = activity.purpose;
         const timelineField = document.getElementById('activity-timeline');
         if (timelineField) {
             timelineField.value = activity.timeline === 'short-term' ? 'short-term' : 'long-term';
@@ -1826,7 +1823,6 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // フォームからデータを取得
         const name = document.getElementById('activity-name').value;
-        const purpose = document.getElementById('activity-purpose').value;
         const timeline = document.getElementById('activity-timeline').value;
         const formProgress = parseInt(document.getElementById('activity-progress').value);
         
@@ -1894,10 +1890,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     calculatedProgress = formProgress;
                 }
                 
+                const { purpose: _deprecatedPurpose, ...activityWithoutPurpose } = oldActivity;
+
                 const updatedActivity = {
-                    ...oldActivity,
+                    ...activityWithoutPurpose,
                     name,
-                    purpose,
                     timeline,
                     progress: calculatedProgress,
                     completed: calculatedProgress >= 100 || oldActivity.completed,
@@ -1948,7 +1945,6 @@ document.addEventListener('DOMContentLoaded', function() {
             const newActivity = {
                 id: generateId(),
                 name,
-                purpose,
                 timeline,
                 progress: calculatedProgress,
                 completed: calculatedProgress >= 100,

--- a/index.html
+++ b/index.html
@@ -167,7 +167,6 @@
                 </div>
                 <div class="header-content">
                     <h1 class="document-title" id="detail-activity-name"></h1>
-                    <p class="document-subtitle" id="detail-activity-purpose"></p>
                     <div class="header-last-updated">最終更新: <span id="detail-last-updated"></span></div>
                 </div>
             </header>
@@ -360,11 +359,6 @@
                     <div class="form-group">
                         <label for="activity-name">事業名</label>
                         <input type="text" id="activity-name" required>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="activity-purpose">目的</label>
-                        <input type="text" id="activity-purpose" required>
                     </div>
 
                     <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -440,13 +440,6 @@ body {
     padding-left: 0.5rem;
 }
 
-.activity-purpose {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    margin-bottom: 0.5rem;
-    padding-left: 0.5rem;
-}
-
 .activity-progress {
     margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- remove the purpose field from the activity detail header and activity form
- update application logic to stop reading, storing, or displaying activity purposes
- tidy related styles that were only used by the purpose field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce9e4fa9d4832ca4a3d039d382a7ed