### PR TITLE
Update assignee labels and align form inputs

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,9 +18,9 @@ document.addEventListener('DOMContentLoaded', function() {
     };
 
     const ASSIGNEE_DISPLAY = {
-        [ASSIGNEES.YU]: { badge: '(ゆ)', title: 'ゆちゃんがやること' },
-        [ASSIGNEES.SAKI]: { badge: '(さ)', title: 'さきたんがやること' },
-        [ASSIGNEES.BOTH]: { badge: '(両)', title: 'ゆちゃんorさきたん' }
+        [ASSIGNEES.YU]: { badge: 'ゆちゃん', title: 'ゆちゃん' },
+        [ASSIGNEES.SAKI]: { badge: 'さきたん', title: 'さきたん' },
+        [ASSIGNEES.BOTH]: { badge: 'ゆちゃんorさきたん', title: 'ゆちゃんorさきたん' }
     };
 
     function normalizeAssignee(value) {
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (['sa', 'さ', 's', 'さき', 'saki', 'さきたん', 'sakitan'].includes(normalized)) {
             return ASSIGNEES.SAKI;
         }
-        if (['both', '両', 'りょう', 'ryo', 'ryou', 'all', 'どちらでも'].includes(normalized)) {
+        if (['both', '両', 'りょう', 'ryo', 'ryou', 'all', 'どちらでも', 'ゆちゃんorさきたん'].includes(normalized)) {
             return ASSIGNEES.BOTH;
         }
 
@@ -42,9 +42,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function getAssigneeOptionsHTML(selectedValue = ASSIGNEES.BOTH) {
         return `
-            <option value="${ASSIGNEES.YU}" ${selectedValue === ASSIGNEES.YU ? 'selected' : ''}>(ゆ) ゆちゃん</option>
-            <option value="${ASSIGNEES.SAKI}" ${selectedValue === ASSIGNEES.SAKI ? 'selected' : ''}>(さ) さきたん</option>
-            <option value="${ASSIGNEES.BOTH}" ${selectedValue === ASSIGNEES.BOTH ? 'selected' : ''}>(両) ゆちゃんorさきたん</option>
+            <option value="${ASSIGNEES.YU}" ${selectedValue === ASSIGNEES.YU ? 'selected' : ''}>ゆちゃん</option>
+            <option value="${ASSIGNEES.SAKI}" ${selectedValue === ASSIGNEES.SAKI ? 'selected' : ''}>さきたん</option>
+            <option value="${ASSIGNEES.BOTH}" ${selectedValue === ASSIGNEES.BOTH ? 'selected' : ''}>ゆちゃんorさきたん</option>
         `;
     }
 
@@ -110,9 +110,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function promptForAssignee(defaultValue = ASSIGNEES.BOTH) {
-        const defaultBadge = ASSIGNEE_DISPLAY[defaultValue]?.badge || '(両)';
-        const defaultInput = defaultBadge.replace(/[()]/g, '');
-        const input = prompt('担当を選択してください：(ゆ)/(さ)/(両)', defaultInput);
+        const defaultBadge = ASSIGNEE_DISPLAY[defaultValue]?.badge || 'ゆちゃんorさきたん';
+        const input = prompt('担当を選択してください：ゆちゃん/さきたん/ゆちゃんorさきたん', defaultBadge);
         if (input === null) {
             return null;
         }

--- a/styles.css
+++ b/styles.css
@@ -1094,9 +1094,16 @@ body {
     font-size: 0.95rem;
 }
 
-.kpi-input-group {
+.input-group.kpi-input-group {
     display: grid;
-    grid-template-columns: 1fr 150px 180px auto;
+    grid-template-columns: minmax(0, 1fr) 150px 180px auto;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.input-group.task-input-group {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 180px auto;
     gap: 0.5rem;
     align-items: center;
 }
@@ -1122,6 +1129,7 @@ body {
 
 .assignee-select {
     min-width: 150px;
+    width: 100%;
     padding: 0.7rem;
     border: 1px solid var(--border-color);
     border-radius: var(--card-radius);
@@ -1140,7 +1148,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 0.8rem;
-    width: a100%; /* Ensure inputs use full width */
+    width: 100%; /* Ensure inputs use full width */
 }
 
 .input-group {


### PR DESCRIPTION
## Summary
- update assignee labels and prompts to remove the old (ゆ)/(さ)/(両) prefixes
- ensure assignee sections now display the simplified names
- adjust the KPI and daily task input layouts so the assignee selector stays on the same row

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cef50cd654832c8182ba48b68f39a4