### PR TITLE
Fix daily task reset to midnight JST

### DIFF
--- a/app.js
+++ b/app.js
@@ -348,14 +348,25 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // 現在の日付を取得
     function getCurrentDate() {
-        return new Date().toISOString().split('T')[0];
+        const formatter = new Intl.DateTimeFormat('ja-JP', {
+            timeZone: 'Asia/Tokyo',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        });
+
+        const parts = formatter.formatToParts(new Date());
+        const year = parts.find(part => part.type === 'year')?.value || '0000';
+        const month = parts.find(part => part.type === 'month')?.value || '00';
+        const day = parts.find(part => part.type === 'day')?.value || '00';
+
+        return `${year}-${month}-${day}`;
     }
 
     // 現在の日付の表示を更新
     function updateCurrentDate() {
-        const today = new Date();
-        const options = { year: 'numeric', month: 'long', day: 'numeric', weekday: 'long' };
-        const formattedDate = today.toLocaleDateString('ja-JP', options);
+        const options = { year: 'numeric', month: 'long', day: 'numeric', weekday: 'long', timeZone: 'Asia/Tokyo' };
+        const formattedDate = new Intl.DateTimeFormat('ja-JP', options).format(new Date());
 
         // 今日のタスクページの日付を更新
         const currentDateElement = document.getElementById('current-date');
@@ -367,12 +378,13 @@ document.addEventListener('DOMContentLoaded', function() {
     // 最終更新日時を更新
     function updateLastUpdated() {
         const now = new Date();
-        const options = { 
-            year: 'numeric', 
-            month: 'long', 
-            day: 'numeric', 
-            hour: '2-digit', 
-            minute: '2-digit' 
+        const options = {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'Asia/Tokyo'
         };
         const formattedDate = now.toLocaleDateString('ja-JP', options);
 


### PR DESCRIPTION
## Summary
- ensure the current date key uses the Asia/Tokyo timezone so daily tasks reset at 0:00 JST
- align displayed current date and last updated timestamp with Japan Standard Time

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8fc8f9940832c9aac87bd3c3c340b