### PR TITLE
Adjust daily task layout for small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -933,7 +933,7 @@ body {
 
 .assignee-sections {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 1rem;
     margin-top: 1rem;
 }
@@ -1022,6 +1022,7 @@ body {
 
 .task-content {
     flex: 1;
+    min-width: 0;
 }
 
 .task-name {
@@ -1416,6 +1417,20 @@ body {
     }
 }
 
+@media (max-width: 1024px) {
+    .assignee-sections {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .daily-task-section {
+        padding: 1.25rem;
+    }
+
+    .assignee-section .daily-task-list {
+        grid-template-columns: 1fr;
+    }
+}
+
 @media (max-width: 768px) {
     .document {
         margin: 0;
@@ -1464,9 +1479,29 @@ body {
     .daily-task-list {
         grid-template-columns: 1fr;
     }
-    
+
     .task-add-form {
         flex-direction: column;
+    }
+
+    .assignee-sections {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+    }
+
+    .assignee-section {
+        width: 100%;
+    }
+
+    .assignee-section .daily-task-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .task-item {
+        padding: 0.9rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- widen daily task columns to give task text more breathing room
- stack assignee sections vertically on tablet and phone breakpoints and ensure lists stay single-column
- add defensive min-width handling so task content can expand without being squeezed

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00293f880832cae6f20cf52027da3