### PR TITLE
Limit mobile KPI layout adjustments to touch devices

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1503,6 +1503,23 @@ body {
     .task-item {
         padding: 0.9rem;
     }
+
+}
+
+@media (max-width: 768px) and (hover: none) and (pointer: coarse) {
+    .input-group.kpi-input-group {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+    }
+
+    .input-group.kpi-input-group input,
+    .input-group.kpi-input-group select {
+        width: 100%;
+    }
+
+    .input-group.kpi-input-group button {
+        justify-self: start;
+    }
 }
 
 @media (orientation: landscape) and (max-height: 820px) {


### PR DESCRIPTION
## Summary
- limit the KPI input vertical stacking to narrow touch devices so desktop layouts remain unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7ab43abd0832cad80fc7da6bda4be